### PR TITLE
(Not so) Small changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
     with:
       target: ${{ matrix.target }}
       channel: ${{ matrix.channel }}
-      target-features: +sse4.1,+aes
+      target-features: +aes
 
   test-aesni-vaes:
     strategy:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In case you discover a bug, please feel free to file an issue at [my repository]
 
 | Implementation                 | Architecture          | Target Feature  |                                                                                        |
 | ------------------------------ | --------------------- | --------------- | -------------------------------------------------------------------------------------- |
-| **AES-NI**                     | `x86`/`x86_64`        | `sse4.1`+`aes`  |                                                                                        |
+| **AES-NI**                     | `x86`/`x86_64`        | `aes`  |                                                                                        |
 | **AES-Neon**                   | `aarch64`/`arm64ec`   | `aes`           |                                                                                        |
 |                                | `arm`                 | `v8`+`aes`      | *Nightly-only*                                                                         |
 | **AES-RV**                     | `riscv32`/`riscv64`   | `zkne`+`zknd`   | *Nightly-only*                                                                         |

--- a/src/aes_ppc.rs
+++ b/src/aes_ppc.rs
@@ -92,14 +92,14 @@ impl AesBlock {
 
     /// `InvShiftRows`->`InvSubBytes`->`AddRoundKey`->`InvMixColumns`
     #[inline]
-    pub(crate) fn dec2(self, round_key: Self) -> Self {
+    pub(crate) fn raw_dec(self, round_key: Self) -> Self {
         Self(unsafe { vncipher(self.0, round_key.0) })
     }
 
     /// Performs one round of AES decryption function (`InvShiftRows`->`InvSubBytes`->`InvMixColumns`->`AddRoundKey`)
     #[inline]
     pub fn dec(self, round_key: Self) -> Self {
-        self.dec2(Self::zero()) ^ round_key
+        self.raw_dec(Self::zero()) ^ round_key
     }
 
     /// Performs one round of AES encryption function without `MixColumns` (`ShiftRows`->`SubBytes`->`AddRoundKey`)

--- a/src/aes_table_based.rs
+++ b/src/aes_table_based.rs
@@ -225,16 +225,16 @@ fn sub_word(x: u32) -> u32 {
     te4_0(x >> 16) | te4_1(x >> 8) | te4_2(x) | te4_3(x >> 24)
 }
 
-fn keyexp_128<const RCON: u32>(prev_rkey: AesBlock) -> AesBlock {
-    let k0 = prev_rkey.0 ^ sub_word(prev_rkey.3) ^ RCON;
+fn keyexp_128(prev_rkey: AesBlock, rcon: u32) -> AesBlock {
+    let k0 = prev_rkey.0 ^ sub_word(prev_rkey.3) ^ rcon;
     let k1 = prev_rkey.1 ^ k0;
     let k2 = prev_rkey.2 ^ k1;
     let k3 = prev_rkey.3 ^ k2;
     AesBlock(k0, k1, k2, k3)
 }
 
-fn keyexp_192<const RCON: u32>(prev: [u32; 6]) -> [u32; 6] {
-    let k0 = prev[0] ^ sub_word(prev[5]) ^ RCON;
+fn keyexp_192(prev: [u32; 6], rcon: u32) -> [u32; 6] {
+    let k0 = prev[0] ^ sub_word(prev[5]) ^ rcon;
     let k1 = prev[1] ^ k0;
     let k2 = prev[2] ^ k1;
     let k3 = prev[3] ^ k2;
@@ -244,8 +244,8 @@ fn keyexp_192<const RCON: u32>(prev: [u32; 6]) -> [u32; 6] {
     [k0, k1, k2, k3, k4, k5]
 }
 
-fn keyexp_256_1<const RCON: u32>(prev0: AesBlock, prev1: AesBlock) -> AesBlock {
-    let k0 = prev0.0 ^ sub_word(prev1.3) ^ RCON;
+fn keyexp_256_1(prev0: AesBlock, prev1: AesBlock, rcon: u32) -> AesBlock {
+    let k0 = prev0.0 ^ sub_word(prev1.3) ^ rcon;
     let k1 = prev0.1 ^ k0;
     let k2 = prev0.2 ^ k1;
     let k3 = prev0.3 ^ k2;
@@ -262,16 +262,16 @@ fn keyexp_256_2(prev0: AesBlock, prev1: AesBlock) -> AesBlock {
 
 pub(super) fn keygen_128(key: [u8; 16]) -> [AesBlock; 11] {
     let key0 = key.into();
-    let key1 = keyexp_128::<0x01000000>(key0);
-    let key2 = keyexp_128::<0x02000000>(key1);
-    let key3 = keyexp_128::<0x04000000>(key2);
-    let key4 = keyexp_128::<0x08000000>(key3);
-    let key5 = keyexp_128::<0x10000000>(key4);
-    let key6 = keyexp_128::<0x20000000>(key5);
-    let key7 = keyexp_128::<0x40000000>(key6);
-    let key8 = keyexp_128::<0x80000000>(key7);
-    let key9 = keyexp_128::<0x1b000000>(key8);
-    let key10 = keyexp_128::<0x36000000>(key9);
+    let key1 = keyexp_128(key0, 0x01000000);
+    let key2 = keyexp_128(key1, 0x02000000);
+    let key3 = keyexp_128(key2, 0x04000000);
+    let key4 = keyexp_128(key3, 0x08000000);
+    let key5 = keyexp_128(key4, 0x10000000);
+    let key6 = keyexp_128(key5, 0x20000000);
+    let key7 = keyexp_128(key6, 0x40000000);
+    let key8 = keyexp_128(key7, 0x80000000);
+    let key9 = keyexp_128(key8, 0x1b000000);
+    let key10 = keyexp_128(key9, 0x36000000);
 
     [
         key0, key1, key2, key3, key4, key5, key6, key7, key8, key9, key10,
@@ -288,25 +288,25 @@ pub(super) fn keygen_192(key: [u8; 24]) -> [AesBlock; 13] {
         load_u32_be(&key, 20),
     ];
     let key0 = AesBlock(k[0], k[1], k[2], k[3]);
-    let p = keyexp_192::<0x01000000>(k);
+    let p = keyexp_192(k, 0x01000000);
     let key1 = AesBlock(k[4], k[5], p[0], p[1]);
     let key2 = AesBlock(p[2], p[3], p[4], p[5]);
-    let k = keyexp_192::<0x02000000>(p);
+    let k = keyexp_192(p, 0x02000000);
     let key3 = AesBlock(k[0], k[1], k[2], k[3]);
-    let p = keyexp_192::<0x04000000>(k);
+    let p = keyexp_192(k, 0x04000000);
     let key4 = AesBlock(k[4], k[5], p[0], p[1]);
     let key5 = AesBlock(p[2], p[3], p[4], p[5]);
-    let k = keyexp_192::<0x08000000>(p);
+    let k = keyexp_192(p, 0x08000000);
     let key6 = AesBlock(k[0], k[1], k[2], k[3]);
-    let p = keyexp_192::<0x10000000>(k);
+    let p = keyexp_192(k, 0x10000000);
     let key7 = AesBlock(k[4], k[5], p[0], p[1]);
     let key8 = AesBlock(p[2], p[3], p[4], p[5]);
-    let k = keyexp_192::<0x20000000>(p);
+    let k = keyexp_192(p, 0x20000000);
     let key9 = AesBlock(k[0], k[1], k[2], k[3]);
-    let p = keyexp_192::<0x40000000>(k);
+    let p = keyexp_192(k, 0x40000000);
     let key10 = AesBlock(k[4], k[5], p[0], p[1]);
     let key11 = AesBlock(p[2], p[3], p[4], p[5]);
-    let k = keyexp_192::<0x80000000>(p);
+    let k = keyexp_192(p, 0x80000000);
     let key12 = AesBlock(k[0], k[1], k[2], k[3]);
 
     [
@@ -318,19 +318,19 @@ pub(super) fn keygen_256(key: [u8; 32]) -> [AesBlock; 15] {
     let key0 = AesBlock::from(array_from_slice(&key, 0));
     let key1 = AesBlock::from(array_from_slice(&key, 16));
 
-    let key2 = keyexp_256_1::<0x01000000>(key0, key1);
+    let key2 = keyexp_256_1(key0, key1, 0x01000000);
     let key3 = keyexp_256_2(key1, key2);
-    let key4 = keyexp_256_1::<0x02000000>(key2, key3);
+    let key4 = keyexp_256_1(key2, key3, 0x02000000);
     let key5 = keyexp_256_2(key3, key4);
-    let key6 = keyexp_256_1::<0x04000000>(key4, key5);
+    let key6 = keyexp_256_1(key4, key5, 0x04000000);
     let key7 = keyexp_256_2(key5, key6);
-    let key8 = keyexp_256_1::<0x08000000>(key6, key7);
+    let key8 = keyexp_256_1(key6, key7, 0x08000000);
     let key9 = keyexp_256_2(key7, key8);
-    let key10 = keyexp_256_1::<0x10000000>(key8, key9);
+    let key10 = keyexp_256_1(key8, key9, 0x10000000);
     let key11 = keyexp_256_2(key9, key10);
-    let key12 = keyexp_256_1::<0x20000000>(key10, key11);
+    let key12 = keyexp_256_1(key10, key11, 0x20000000);
     let key13 = keyexp_256_2(key11, key12);
-    let key14 = keyexp_256_1::<0x40000000>(key12, key13);
+    let key14 = keyexp_256_1(key12, key13, 0x40000000);
 
     [
         key0, key1, key2, key3, key4, key5, key6, key7, key8, key9, key10, key11, key12, key13,

--- a/src/aesni_x4.rs
+++ b/src/aesni_x4.rs
@@ -12,6 +12,13 @@ use crate::{AesBlock, AesBlockX2};
 #[must_use]
 pub struct AesBlockX4(__m512i);
 
+impl PartialEq for AesBlockX4 {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { _mm512_cmpeq_epi64_mask(self.0, other.0) == 0xff }
+    }
+}
+
 impl From<(AesBlock, AesBlock, AesBlock, AesBlock)> for AesBlockX4 {
     #[inline]
     #[allow(clippy::many_single_char_names)]

--- a/src/blockcipher.rs
+++ b/src/blockcipher.rs
@@ -315,7 +315,7 @@ macro_rules! implement_aes {
                     fn decrypt_block(&self, ciphertext: AesBlock) -> AesBlock {
                         let mut acc = ciphertext ^ self.round_keys[$nr];
                         for &drk in self.round_keys[1..$nr].iter().rev() {
-                            acc = acc.dec2(drk);
+                            acc = acc.raw_dec(drk);
                         }
                         acc.dec_last(self.round_keys[0])
                     }

--- a/src/blockcipher.rs
+++ b/src/blockcipher.rs
@@ -1,9 +1,16 @@
 use crate::*;
 use cfg_if::cfg_if;
+use core::array;
 use core::fmt::Debug;
 
 mod private {
     pub trait Sealed {}
+}
+
+#[allow(unused)]
+#[inline(always)]
+fn transpose<T: Copy, const M: usize, const N: usize>(array: [[T; M]; N]) -> [[T; N]; M] {
+    array::from_fn(|i| array::from_fn(|j| array[j][i]))
 }
 
 pub trait AesEncrypt<const KEY_LEN: usize>:
@@ -15,8 +22,10 @@ pub trait AesEncrypt<const KEY_LEN: usize>:
 
     fn encrypt_block(&self, plaintext: AesBlock) -> AesBlock;
 
+    /// Encrypt two blocks, *using the same key*
     fn encrypt_2_blocks(&self, plaintext: AesBlockX2) -> AesBlockX2;
 
+    /// Encrypt four blocks, *using the same key*
     fn encrypt_4_blocks(&self, plaintext: AesBlockX4) -> AesBlockX4;
 }
 
@@ -29,8 +38,60 @@ pub trait AesDecrypt<const KEY_LEN: usize>:
 
     fn decrypt_block(&self, plaintext: AesBlock) -> AesBlock;
 
+    /// Decrypt two blocks, *using the same key*
     fn decrypt_2_blocks(&self, ciphertext: AesBlockX2) -> AesBlockX2;
 
+    /// Decrypt four blocks, *using the same key*
+    fn decrypt_4_blocks(&self, ciphertext: AesBlockX4) -> AesBlockX4;
+}
+
+pub trait AesEncryptX2<const KEY_LEN: usize>:
+    From<[[u8; KEY_LEN]; 2]> + private::Sealed + Debug + Clone
+{
+    type Decrypter: AesDecryptX2<KEY_LEN, Encrypter = Self>;
+
+    fn decrypter(&self) -> Self::Decrypter;
+
+    /// Encrypt two blocks, using the first key for the first block, and the second key for the second block
+    fn encrypt_2_blocks(&self, plaintext: AesBlockX2) -> AesBlockX2;
+
+    /// Encrypt four blocks, using the first key for the first two blocks, and the second key for the second two blocks
+    fn encrypt_4_blocks(&self, plaintext: AesBlockX4) -> AesBlockX4;
+}
+
+pub trait AesDecryptX2<const KEY_LEN: usize>:
+    From<[[u8; KEY_LEN]; 2]> + private::Sealed + Debug + Clone
+{
+    type Encrypter: AesEncryptX2<KEY_LEN, Decrypter = Self>;
+
+    fn encrypter(&self) -> Self::Encrypter;
+
+    /// Decrypt two blocks, using the first key for the first block, and the second key for the second block
+    fn decrypt_2_blocks(&self, ciphertext: AesBlockX2) -> AesBlockX2;
+
+    /// Decrypt four blocks, using the first key for the first two blocks, and the second key for the second two blocks
+    fn decrypt_4_blocks(&self, ciphertext: AesBlockX4) -> AesBlockX4;
+}
+
+pub trait AesEncryptX4<const KEY_LEN: usize>:
+    From<[[u8; KEY_LEN]; 4]> + private::Sealed + Debug + Clone
+{
+    type Decrypter: AesDecryptX4<KEY_LEN, Encrypter = Self>;
+
+    fn decrypter(&self) -> Self::Decrypter;
+
+    /// Encrypt four blocks, using the four keys for the four blocks respectively
+    fn encrypt_4_blocks(&self, plaintext: AesBlockX4) -> AesBlockX4;
+}
+
+pub trait AesDecryptX4<const KEY_LEN: usize>:
+    From<[[u8; KEY_LEN]; 4]> + private::Sealed + Debug + Clone
+{
+    type Encrypter: AesEncryptX4<KEY_LEN, Decrypter = Self>;
+
+    fn encrypter(&self) -> Self::Encrypter;
+
+    /// Decrypt four blocks, using the four keys for the four blocks respectively
     fn decrypt_4_blocks(&self, ciphertext: AesBlockX4) -> AesBlockX4;
 }
 
@@ -352,3 +413,370 @@ macro_rules! implement_aes {
 implement_aes!(Aes128Enc, Aes128Dec, 16, 10, keygen_128);
 implement_aes!(Aes192Enc, Aes192Dec, 24, 12, keygen_192);
 implement_aes!(Aes256Enc, Aes256Dec, 32, 14, keygen_256);
+
+cfg_if! {
+    // Only interleave the keys if we have a decent enough X2 implementation
+    if #[cfg(all(
+        feature = "nightly",
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_feature = "vaes"
+    ))] {
+
+        #[inline(always)]
+        fn dec_round_keys_x2<const N: usize>(enc_round_keys: &[AesBlockX2; N]) -> [AesBlockX2; N] {
+            let mut drk = [AesBlockX2::zero(); N];
+            drk[0] = enc_round_keys[N - 1];
+            for i in 1..(N - 1) {
+                drk[i] = enc_round_keys[N - 1 - i].imc();
+            }
+            drk[N - 1] = enc_round_keys[0];
+            drk
+        }
+
+        #[inline(always)]
+        fn enc_round_keys_x2<const N: usize>(dec_round_keys: &[AesBlockX2; N]) -> [AesBlockX2; N] {
+            let mut rk = [AesBlockX2::zero(); N];
+            rk[0] = dec_round_keys[N - 1];
+            for i in 1..(N - 1) {
+                rk[i] = dec_round_keys[N - 1 - i].mc();
+            }
+            rk[N - 1] = dec_round_keys[0];
+            rk
+        }
+
+        macro_rules! implement_aes_x2 {
+            ($enc_name:ident, $dec_name:ident, $key_len:literal, $nr:literal, $keygen:ident) => {
+
+                #[derive(Debug, Clone)]
+                pub struct $enc_name {
+                    round_keys: [AesBlockX2; { $nr + 1 }],
+                }
+
+                impl private::Sealed for $enc_name {}
+
+                impl From<[[u8; $key_len]; 2]> for $enc_name {
+                    /// Returns an encrypter with the provided key
+                    fn from(value: [[u8; $key_len]; 2]) -> Self {
+                        $enc_name {
+                            round_keys: transpose(value.map($keygen)).map(Into::into),
+                        }
+                    }
+                }
+
+                #[derive(Debug, Clone)]
+                pub struct $dec_name {
+                    round_keys: [AesBlockX2; { $nr + 1 }],
+                }
+
+                impl private::Sealed for $dec_name {}
+
+                impl From<[[u8; $key_len]; 2]> for $dec_name {
+                    /// Returns an decrypter with the provided key
+                    fn from(value: [[u8; $key_len]; 2]) -> Self {
+                        $enc_name::from(value).decrypter()
+                    }
+                }
+
+                impl AesEncryptX2<$key_len> for $enc_name {
+                    type Decrypter = $dec_name;
+
+                    fn decrypter(&self) -> Self::Decrypter {
+                        $dec_name {
+                            round_keys: dec_round_keys_x2(&self.round_keys),
+                        }
+                    }
+
+                    fn encrypt_2_blocks(&self, plaintext: AesBlockX2) -> AesBlockX2 {
+                        plaintext.chain_enc_with_last(&self.round_keys)
+                    }
+
+                    fn encrypt_4_blocks(&self, plaintext: AesBlockX4) -> AesBlockX4 {
+                        let round_keys = self.round_keys.map(Into::into);
+                        plaintext.chain_enc_with_last(&round_keys)
+                    }
+                }
+
+                impl AesDecryptX2<$key_len> for $dec_name {
+                    type Encrypter = $enc_name;
+
+                    fn encrypter(&self) -> Self::Encrypter {
+                        $enc_name {
+                            round_keys: enc_round_keys_x2(&self.round_keys),
+                        }
+                    }
+
+                    fn decrypt_2_blocks(&self, ciphertext: AesBlockX2) -> AesBlockX2 {
+                        ciphertext.chain_dec_with_last(&self.round_keys)
+                    }
+
+                    fn decrypt_4_blocks(&self, ciphertext: AesBlockX4) -> AesBlockX4 {
+                        let round_keys = self.round_keys.map(Into::into);
+                        ciphertext.chain_dec_with_last(&round_keys)
+                    }
+                }
+            }
+        }
+
+        implement_aes_x2!(Aes128EncX2, Aes128DecX2, 16, 10, keygen_128);
+        implement_aes_x2!(Aes192EncX2, Aes192DecX2, 24, 12, keygen_192);
+        implement_aes_x2!(Aes256EncX2, Aes256DecX2, 32, 14, keygen_256);
+    } else {
+        // otherwise just use a tuple
+
+        macro_rules! implement_aes_x2 {
+            ($enc_name:ident, $dec_name:ident, $key_len:literal, $nr:literal, $base_enc:ident, $base_dec:ident) => {
+
+                #[derive(Debug, Clone)]
+                pub struct $enc_name {
+                    inner: [$base_enc; 2],
+                }
+
+                impl private::Sealed for $enc_name {}
+
+                impl From<[[u8; $key_len]; 2]> for $enc_name {
+                    /// Returns an encrypter with the provided key
+                    fn from(value: [[u8; $key_len]; 2]) -> Self {
+                        $enc_name {
+                            inner: value.map(Into::into),
+                        }
+                    }
+                }
+
+                #[derive(Debug, Clone)]
+                pub struct $dec_name {
+                    inner: [$base_dec; 2],
+                }
+
+                impl private::Sealed for $dec_name {}
+
+                impl From<[[u8; $key_len]; 2]> for $dec_name {
+                    /// Returns an decrypter with the provided key
+                    fn from(value: [[u8; $key_len]; 2]) -> Self {
+                        $dec_name {
+                            inner: value.map(Into::into),
+                        }
+                    }
+                }
+
+                impl AesEncryptX2<$key_len> for $enc_name {
+                    type Decrypter = $dec_name;
+
+                    fn decrypter(&self) -> Self::Decrypter {
+                        $dec_name {
+                            inner: self.inner.each_ref().map($base_enc::decrypter),
+                        }
+                    }
+
+                    fn encrypt_2_blocks(&self, plaintext: AesBlockX2) -> AesBlockX2 {
+                        let (a, b) = plaintext.into();
+                        (self.inner[0].encrypt_block(a), self.inner[1].encrypt_block(b)).into()
+                    }
+
+                    fn encrypt_4_blocks(&self, plaintext: AesBlockX4) -> AesBlockX4 {
+                        let (a, b) = plaintext.into();
+                        (self.inner[0].encrypt_2_blocks(a), self.inner[1].encrypt_2_blocks(b)).into()
+                    }
+                }
+
+                impl AesDecryptX2<$key_len> for $dec_name {
+                    type Encrypter = $enc_name;
+
+                    fn encrypter(&self) -> Self::Encrypter {
+                        $enc_name {
+                            inner: self.inner.each_ref().map($base_dec::encrypter),
+                        }
+                    }
+
+                    fn decrypt_2_blocks(&self, ciphertext: AesBlockX2) -> AesBlockX2 {
+                        let (a, b) = ciphertext.into();
+                        (self.inner[0].decrypt_block(a), self.inner[1].decrypt_block(b)).into()
+                    }
+
+                    fn decrypt_4_blocks(&self, ciphertext: AesBlockX4) -> AesBlockX4 {
+                        let (a, b) = ciphertext.into();
+                        (self.inner[0].decrypt_2_blocks(a), self.inner[1].decrypt_2_blocks(b)).into()
+                    }
+                }
+            }
+        }
+
+        implement_aes_x2!(Aes128EncX2, Aes128DecX2, 16, 10, Aes128Enc, Aes128Dec);
+        implement_aes_x2!(Aes192EncX2, Aes192DecX2, 24, 12, Aes192Enc, Aes192Dec);
+        implement_aes_x2!(Aes256EncX2, Aes256DecX2, 32, 14, Aes256Enc, Aes256Dec);
+    }
+}
+
+cfg_if! {
+    // Only interleave the keys if we have a decent enough X4 implementation
+    if #[cfg(all(
+        feature = "nightly",
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_feature = "vaes",
+        target_feature = "avx512f"
+    ))] {
+
+        #[inline(always)]
+        fn dec_round_keys_x4<const N: usize>(enc_round_keys: &[AesBlockX4; N]) -> [AesBlockX4; N] {
+            let mut drk = [AesBlockX4::zero(); N];
+            drk[0] = enc_round_keys[N - 1];
+            for i in 1..(N - 1) {
+                drk[i] = enc_round_keys[N - 1 - i].imc();
+            }
+            drk[N - 1] = enc_round_keys[0];
+            drk
+        }
+
+        #[inline(always)]
+        fn enc_round_keys_x4<const N: usize>(dec_round_keys: &[AesBlockX4; N]) -> [AesBlockX4; N] {
+            let mut rk = [AesBlockX4::zero(); N];
+            rk[0] = dec_round_keys[N - 1];
+            for i in 1..(N - 1) {
+                rk[i] = dec_round_keys[N - 1 - i].mc();
+            }
+            rk[N - 1] = dec_round_keys[0];
+            rk
+        }
+
+        macro_rules! implement_aes_x4 {
+            ($enc_name:ident, $dec_name:ident, $key_len:literal, $nr:literal, $keygen:ident) => {
+
+                #[derive(Debug, Clone)]
+                pub struct $enc_name {
+                    round_keys: [AesBlockX4; { $nr + 1 }],
+                }
+
+                impl private::Sealed for $enc_name {}
+
+                impl From<[[u8; $key_len]; 4]> for $enc_name {
+                    /// Returns an encrypter with the provided key
+                    fn from(value: [[u8; $key_len]; 4]) -> Self {
+                        $enc_name {
+                            round_keys: transpose(value.map($keygen)).map(Into::into),
+                        }
+                    }
+                }
+
+                #[derive(Debug, Clone)]
+                pub struct $dec_name {
+                    round_keys: [AesBlockX4; { $nr + 1 }],
+                }
+
+                impl private::Sealed for $dec_name {}
+
+                impl From<[[u8; $key_len]; 4]> for $dec_name {
+                    /// Returns an decrypter with the provided key
+                    fn from(value: [[u8; $key_len]; 4]) -> Self {
+                        $enc_name::from(value).decrypter()
+                    }
+                }
+
+                impl AesEncryptX4<$key_len> for $enc_name {
+                    type Decrypter = $dec_name;
+
+                    fn decrypter(&self) -> Self::Decrypter {
+                        $dec_name {
+                            round_keys: dec_round_keys_x4(&self.round_keys),
+                        }
+                    }
+
+                    fn encrypt_4_blocks(&self, plaintext: AesBlockX4) -> AesBlockX4 {
+                        plaintext.chain_enc_with_last(&self.round_keys)
+                    }
+                }
+
+                impl AesDecryptX4<$key_len> for $dec_name {
+                    type Encrypter = $enc_name;
+
+                    fn encrypter(&self) -> Self::Encrypter {
+                        $enc_name {
+                            round_keys: enc_round_keys_x4(&self.round_keys),
+                        }
+                    }
+
+                    fn decrypt_4_blocks(&self, ciphertext: AesBlockX4) -> AesBlockX4 {
+                        ciphertext.chain_dec_with_last(&self.round_keys)
+                    }
+                }
+            }
+        }
+
+        implement_aes_x4!(Aes128EncX4, Aes128DecX4, 16, 10, keygen_128);
+        implement_aes_x4!(Aes192EncX4, Aes192DecX4, 24, 12, keygen_192);
+        implement_aes_x4!(Aes256EncX4, Aes256DecX4, 32, 14, keygen_256);
+    } else {
+        // otherwise just use a tuple
+
+        macro_rules! implement_aes_x4 {
+            ($enc_name:ident, $dec_name:ident, $key_len:literal, $nr:literal, $base_enc:ident, $base_dec:ident) => {
+
+                #[derive(Debug, Clone)]
+                pub struct $enc_name {
+                    inner: [$base_enc; 2],
+                }
+
+                impl private::Sealed for $enc_name {}
+
+                impl From<[[u8; $key_len]; 4]> for $enc_name {
+                    /// Returns an encrypter with the provided key
+                    fn from(value: [[u8; $key_len]; 4]) -> Self {
+                        let value: [[[u8; $key_len]; 2]; 2] = unsafe { core::mem::transmute(value) };
+                        $enc_name {
+                            inner: value.map(Into::into),
+                        }
+                    }
+                }
+
+                #[derive(Debug, Clone)]
+                pub struct $dec_name {
+                    inner: [$base_dec; 2],
+                }
+
+                impl private::Sealed for $dec_name {}
+
+                impl From<[[u8; $key_len]; 4]> for $dec_name {
+                    /// Returns an decrypter with the provided key
+                    fn from(value: [[u8; $key_len]; 4]) -> Self {
+                        let value: [[[u8; $key_len]; 2]; 2] = unsafe { core::mem::transmute(value) };
+                        $dec_name {
+                            inner: value.map(Into::into),
+                        }
+                    }
+                }
+
+                impl AesEncryptX4<$key_len> for $enc_name {
+                    type Decrypter = $dec_name;
+
+                    fn decrypter(&self) -> Self::Decrypter {
+                        $dec_name {
+                            inner: self.inner.each_ref().map($base_enc::decrypter),
+                        }
+                    }
+
+                    fn encrypt_4_blocks(&self, plaintext: AesBlockX4) -> AesBlockX4 {
+                        let (a, b) = plaintext.into();
+                        (self.inner[0].encrypt_2_blocks(a), self.inner[1].encrypt_2_blocks(b)).into()
+                    }
+                }
+
+                impl AesDecryptX4<$key_len> for $dec_name {
+                    type Encrypter = $enc_name;
+
+                    fn encrypter(&self) -> Self::Encrypter {
+                        $enc_name {
+                            inner: self.inner.each_ref().map($base_dec::encrypter),
+                        }
+                    }
+
+                    fn decrypt_4_blocks(&self, ciphertext: AesBlockX4) -> AesBlockX4 {
+                        let (a, b) = ciphertext.into();
+                        (self.inner[0].decrypt_2_blocks(a), self.inner[1].decrypt_2_blocks(b)).into()
+                    }
+                }
+            }
+        }
+
+        implement_aes_x4!(Aes128EncX4, Aes128DecX4, 16, 10, Aes128EncX2, Aes128DecX2);
+        implement_aes_x4!(Aes192EncX4, Aes192DecX4, 24, 12, Aes192EncX2, Aes192DecX2);
+        implement_aes_x4!(Aes256EncX4, Aes256DecX4, 32, 14, Aes256EncX2, Aes256DecX2);
+    }
+}

--- a/src/blockcipher.rs
+++ b/src/blockcipher.rs
@@ -86,12 +86,14 @@ cfg_if! {
         macro_rules! impl_aese_aesd {
             ($($name:ident),*) => {$(
                 impl $name {
+                    #[inline(always)]
                     fn aese(self, round_key: Self) -> Self {
                         let (a, b) = self.into();
                         let (rk_a, rk_b) = round_key.into();
                         (a.aese(rk_a), b.aese(rk_b)).into()
                     }
 
+                    #[inline(always)]
                     fn aesd(self, round_key: Self) -> Self {
                         let (a, b) = self.into();
                         let (rk_a, rk_b) = round_key.into();
@@ -110,6 +112,7 @@ cfg_if! {
                     ///
                     /// # Panics
                     /// If `keys.len() == 0`
+                    #[inline]
                     pub fn chain_enc(self, keys: &[$name]) -> $name {
                         assert_ne!(keys.len(), 0);
 
@@ -124,6 +127,7 @@ cfg_if! {
                     ///
                     /// # Panics
                     /// If `keys.len() == 0`
+                    #[inline]
                     pub fn chain_dec(self, keys: &[$name]) -> $name {
                         assert_ne!(keys.len(), 0);
 
@@ -138,6 +142,7 @@ cfg_if! {
                     ///
                     /// # Panics
                     /// If `keys.len() < 2`
+                    #[inline]
                     pub fn chain_enc_with_last(self, keys: &[$name]) -> $name {
                         assert!(keys.len() >= 2);
 
@@ -152,6 +157,7 @@ cfg_if! {
                     ///
                     /// # Panics
                     /// If `keys.len() < 2`
+                    #[inline]
                     pub fn chain_dec_with_last(self, keys: &[$name]) -> $name {
                         assert!(keys.len() >= 2);
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,7 +3,6 @@ use core::fmt;
 use core::fmt::{Binary, Debug, Display, Formatter, LowerHex, UpperHex};
 use core::ops::{BitAndAssign, BitOrAssign, BitXorAssign};
 
-#[allow(unused)]
 #[inline(always)]
 pub(crate) const fn array_from_slice<const N: usize>(value: &[u8], offset: usize) -> [u8; N] {
     debug_assert!(value.len() - offset >= N);
@@ -44,6 +43,12 @@ impl PartialEq for AesBlockX2 {
     }
 }
 
+#[cfg(not(all(
+    feature = "nightly",
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "vaes",
+    target_feature = "avx512f"
+)))]
 impl PartialEq for AesBlockX4 {
     #[inline]
     fn eq(&self, other: &Self) -> bool {

--- a/src/common.rs
+++ b/src/common.rs
@@ -56,6 +56,51 @@ impl PartialEq for AesBlockX4 {
     }
 }
 
+impl From<[AesBlock; 2]> for AesBlockX2 {
+    #[inline]
+    fn from([a, b]: [AesBlock; 2]) -> Self {
+        (a, b).into()
+    }
+}
+
+impl From<AesBlockX2> for [AesBlock; 2] {
+    #[inline]
+    fn from(value: AesBlockX2) -> Self {
+        let (a, b) = value.into();
+        [a, b]
+    }
+}
+
+impl From<[AesBlockX2; 2]> for AesBlockX4 {
+    #[inline]
+    fn from([a, b]: [AesBlockX2; 2]) -> Self {
+        (a, b).into()
+    }
+}
+
+impl From<AesBlockX4> for [AesBlockX2; 2] {
+    #[inline]
+    fn from(value: AesBlockX4) -> Self {
+        let (a, b) = value.into();
+        [a, b]
+    }
+}
+
+impl From<[AesBlock; 4]> for AesBlockX4 {
+    #[inline]
+    fn from([a, b, c, d]: [AesBlock; 4]) -> Self {
+        (a, b, c, d).into()
+    }
+}
+
+impl From<AesBlockX4> for [AesBlock; 4] {
+    #[inline]
+    fn from(value: AesBlockX4) -> Self {
+        let (a, b, c, d) = value.into();
+        [a, b, c, d]
+    }
+}
+
 macro_rules! impl_common_ops {
     ($($name:ty, $key_len:literal),*) => {$(
         impl Eq for $name {}

--- a/src/common.rs
+++ b/src/common.rs
@@ -26,15 +26,33 @@ impl From<AesBlock> for u128 {
     }
 }
 
+#[cfg(not(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "aes"
+)))]
+impl PartialEq for AesBlock {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        (*self ^ *other).is_zero()
+    }
+}
+
+impl PartialEq for AesBlockX2 {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        (*self ^ *other).is_zero()
+    }
+}
+
+impl PartialEq for AesBlockX4 {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        (*self ^ *other).is_zero()
+    }
+}
+
 macro_rules! impl_common_ops {
     ($($name:ty, $key_len:literal),*) => {$(
-        impl PartialEq for $name {
-            #[inline]
-            fn eq(&self, other: &Self) -> bool {
-                (*self ^ *other).is_zero()
-            }
-        }
-
         impl Eq for $name {}
 
         impl $name {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,6 @@ use cfg_if::cfg_if;
 cfg_if! {
     if #[cfg(all(
         any(target_arch = "x86", target_arch = "x86_64"),
-        target_feature = "sse4.1",
         target_feature = "aes",
     ))] {
         #[path = "aes_x86.rs"]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -238,3 +238,67 @@ fn aes_256_test() {
 
     aes_test!(dec: dec, AES_256_VECTORS);
 }
+
+#[test]
+fn aes_128_x2_test() {
+    let key0 = <[u8; 16]>::from_hex("0123456789abcdeffedcba9876543210").unwrap();
+    let key1 = <[u8; 16]>::from_hex("000102030405060708090a0b0c0d0e0f").unwrap();
+
+    let block0 = AES_128_VECTORS[0].0;
+    let block1 = AES_128_VECTORS[1].0;
+
+    assert_eq!(
+        Aes128EncX2::from([key0, key1]).encrypt_2_blocks((block0, block1).into()),
+        (
+            Aes128Enc::from(key0).encrypt_block(block0),
+            Aes128Enc::from(key1).encrypt_block(block1)
+        )
+            .into()
+    );
+
+    assert_eq!(
+        Aes128DecX2::from([key0, key1]).decrypt_2_blocks((block0, block1).into()),
+        (
+            Aes128Dec::from(key0).decrypt_block(block0),
+            Aes128Dec::from(key1).decrypt_block(block1)
+        )
+            .into()
+    );
+}
+
+#[test]
+fn aes_128_x4_test() {
+    let key0 = <[u8; 16]>::from_hex("0123456789abcdeffedcba9876543210").unwrap();
+    let key1 = <[u8; 16]>::from_hex("000102030405060708090a0b0c0d0e0f").unwrap();
+    let key2 = <[u8; 16]>::from_hex("0f0e0d0c0b0a09080706050403020100").unwrap();
+    let key3 = <[u8; 16]>::from_hex("00102030405060708090a0b0c0d0e0f0").unwrap();
+
+    let block0 = AES_128_VECTORS[0].0;
+    let block1 = AES_128_VECTORS[1].0;
+    let block2 = AES_128_VECTORS[2].0;
+    let block3 = AES_128_VECTORS[3].0;
+
+    assert_eq!(
+        Aes128EncX4::from([key0, key1, key2, key3])
+            .encrypt_4_blocks((block0, block1, block2, block3).into()),
+        (
+            Aes128Enc::from(key0).encrypt_block(block0),
+            Aes128Enc::from(key1).encrypt_block(block1),
+            Aes128Enc::from(key2).encrypt_block(block2),
+            Aes128Enc::from(key3).encrypt_block(block3)
+        )
+            .into()
+    );
+
+    assert_eq!(
+        Aes128DecX4::from([key0, key1, key2, key3])
+            .decrypt_4_blocks((block0, block1, block2, block3).into()),
+        (
+            Aes128Dec::from(key0).decrypt_block(block0),
+            Aes128Dec::from(key1).decrypt_block(block1),
+            Aes128Dec::from(key2).decrypt_block(block2),
+            Aes128Dec::from(key3).decrypt_block(block3)
+        )
+            .into()
+    );
+}


### PR DESCRIPTION
 - Add missed inlining
 - Modularize `aes_x86` more
 - Remove uses of unnecessary const-generics
 - Drop `sse4.1` requirement of AES-NI impl
 - Simplify keygen of RV64 and Table-based backend
 - Optimize equality for AVX512 backend
 - Implement conversions from/to arrays (analogous to tuples) for vector AES
 - Add `Aes{En,De}cryptX{2,4}` traits